### PR TITLE
Fix unixstamp bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ composer require forthelocal/laravel-tokens
 ```php
 class User extends Model
 {
-    use Tokenizalbe;
+    use Tokenizable;
 }
 
 // create a new user; remember that the token requires an existing record

--- a/database/migrations/2017_11_10_000001_create_table_tokens.php
+++ b/database/migrations/2017_11_10_000001_create_table_tokens.php
@@ -20,7 +20,7 @@ class CreateTableTokens extends Migration
             $table->string('tokenizable_type');
             $table->string('token');
             $table->text('data')->nullable();
-            $table->dateTime('expires_at')->nullable();
+            $table->integer('expires_at')->nullable();
             $table->timestamp('created_at');
             $table->index(['tokenizable_type', 'tokenizable_id']);
             $table->index('token');


### PR DESCRIPTION
- `expires_at`はunix timestampだが、migrationでのデータ型はdateTimeになっていた
  - 正しくはintegerになるはず
- READMEのtypo修正